### PR TITLE
Support for running on Java 11 + run with liberty 19.0.0.8.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'net.wasdev.wlp.gradle.plugins:liberty-gradle-plugin:2.6.3'
+        classpath 'net.wasdev.wlp.gradle.plugins:liberty-gradle-plugin:2.6.5'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ repositories {
 dependencies {
     libertyRuntime group: 'com.ibm.websphere.appserver.runtime', name: 'wlp-javaee7', version: '17.0.0.2'
 
+    compile 'com.sun.xml.ws:jaxws-ri:2.3.2'
     providedCompile group: 'org.apache.cxf', name: 'cxf-rt-rs-client', version:'3.1.1'
     providedCompile group: 'org.glassfish', name: 'javax.json', version:'1.0.4'
     providedCompile group: 'javax.servlet', name: 'javax.servlet-api', version:'3.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+apply plugin: 'java'
 apply plugin: 'war'
 apply plugin: 'liberty'
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ repositories {
 }
 
 dependencies {
-    libertyRuntime group: 'com.ibm.websphere.appserver.runtime', name: 'wlp-javaee7', version: '17.0.0.2'
+    libertyRuntime group: 'com.ibm.websphere.appserver.runtime', name: 'wlp-javaee8', version: '19.0.0.8'
 
     compile 'com.sun.xml.ws:jaxws-ri:2.3.2'
     providedCompile group: 'org.apache.cxf', name: 'cxf-rt-rs-client', version:'3.1.1'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip


### PR DESCRIPTION
Minor changes to build.gradle and upgraded gradlew wrapper for Java 11 support.

Did not find any test-cases to run, but I did try every form on the /jaxws endpoint :)